### PR TITLE
New pbpack format support and crc calculator tool

### DIFF
--- a/calculateCrc.py
+++ b/calculateCrc.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import sys
+from libpebble.stm32_crc import crc32
+
+if len(sys.argv) <= 1 or sysv.argv[1] == '-h':
+	print 'calculateCrc.py calculates STM32 CRC sum for a given file or stdin'
+	print 'Usage: calculateCrc.py filename'
+	print 'Use `-\' as filename to read from stdin.'
+	exit()
+
+filename = sys.argv[1]
+f = sys.stdin if filename == '-' else open(filename, 'rb')
+c = crc32(f.read())
+print 'Checksum for %s:' % (filename if filename!='-' else '<stdin>')
+print 'Hex: 0x%08X\nDec: %d' % (c, c)

--- a/calculateCrc.py
+++ b/calculateCrc.py
@@ -3,7 +3,7 @@
 import sys
 from libpebble.stm32_crc import crc32
 
-if len(sys.argv) <= 1 or sysv.argv[1] == '-h':
+if len(sys.argv) <= 1 or sys.argv[1] == '-h':
 	print 'calculateCrc.py calculates STM32 CRC sum for a given file or stdin'
 	print 'Usage: calculateCrc.py filename'
 	print 'Use `-\' as filename to read from stdin.'

--- a/prepareResourceProject.py
+++ b/prepareResourceProject.py
@@ -108,6 +108,9 @@ if __name__ == "__main__":
 		exit(1)
 	
 	print " # Creating symlink..."
-	os.symlink("app/build/app_resources.pbpack", "../system_resources.new.pbpack")
+	if os.path.exists("../system_resources.new.pbpack"):
+		print "Already exists."
+	else:
+		os.symlink("app/build/app_resources.pbpack", "../system_resources.new.pbpack")
 	print " # Done! You may get pbpack at system_resources.new.pbpack"
 	print "   Also you may rebuild it with:  cd app; ./waf build"

--- a/prepareResourceProject.py
+++ b/prepareResourceProject.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+import sys
+import os, os.path
+import json
+from subprocess import call
+
+def fail(msg = "Failed."):
+	print msg
+	exit(1)
+
+def analyzeResources(useManifest, pathToRes):
+	r = []
+	if useManifest:
+		with open("manifest.json", "r") as f:
+			manifest = json.load(f)
+		if "resourceMap" in manifest["debug"]:
+			rm = manifest["debug"]["resourceMap"]["media"]
+		else:
+			print "##########################################################"
+			print "      Error!!! Manifest contains no resourceMap!"
+			print "It must be a 2.0 firmware! Don't use this method with it!"
+			print "##########################################################"
+			rm = []
+			fail() # if you want to make this a warning rather an error, remove this line
+		for i in rm:
+			item = {"type": "raw",
+				"defName": i["defName"],
+				"file": os.path.dirname(i["file"]) + "/" + i["defName"]}
+			if os.path.exists(item["file"]):
+				print "Adding resource %s as %s..." % (i['file'], i['defName'])
+				r.append(item)
+				fullpath = pathToRes + "/" + item["file"]
+				if not os.path.exists(os.path.dirname(fullpath)):
+					os.mkdir(os.path.dirname(fullpath))
+				os.link(item["file"], fullpath)
+	if os.path.isdir("res"):
+		files = os.listdir("res")
+		filter(lambda x: len(x)>4 and x[0].isdigit() and x[1].isdigit() and x[2]=="_", files)
+		files.sort()
+		for i in files:
+			n = int(i[:2])
+			if n < len(r):
+				continue
+			item = {"type": "raw",
+				"defName": i,
+				"file": "res/" + i}
+			print "Adding resourse %s..." % i
+			r.append(item)
+			fullpath = pathToRes + "/" + item["file"]
+			if not os.path.exists(os.path.dirname(fullpath)):
+				os.mkdir(os.path.dirname(fullpath))
+			os.link(item["file"], fullpath)
+	return r
+
+def ver1(sdk):
+	cpr = sdk+"../tools/create_pebble_project.py"
+	if not os.path.isfile(cpr):
+		print "This doesn't look like a usable Pebble 1.x SDK:"
+		print "Couldn't read " + cpr
+		exit(1)
+	
+	if os.path.exists("app"):
+		fail("./app/: path already exists!")
+
+	print " # Creating project..."
+	call([cpr, sdk, "app"]) == 0 or fail()
+
+	print " # Analyzing resources..."
+	res = analyzeResources(True, "app/resources/src")
+	print res
+
+	print " # Populating resource data..."
+	with open("app/resources/src/resource_map.json", "r+") as f:
+		obj = json.load(f)
+		obj['media'] = res
+		obj['friendlyVersion'] = "v1.10-JW"
+		#obj['versionDefName'] = "v1.10-JW" # buggy
+		f.seek(0)
+		json.dump(obj, f, indent=4)
+
+	print " # Configuring project..."
+	os.chdir("app")
+	call("./waf configure", shell=True) == 0 or fail()
+	print " # Building project..."
+	call("./waf build", shell=True) == 0 or fail()
+
+def ver2(sdk):
+	print "Not implemented yet."
+	pass
+
+if __name__ == "__main__":
+	if len(sys.argv) < 3 or sys.argv[1] == "-h":
+		print "Usage: %s ( -1 | -2 ) /path/to/Pebble/SDK/" % __file__
+		print "Assuming that current directory is one with unpacked firmware."
+		print "Will create a new project in directory `app' and configure it to pack resources."
+		exit()
+	sdk = sys.argv[2]
+	if not os.path.isdir(sdk):
+		print "%s is not a directory!" % sdk
+		exit(1)
+	if sys.argv[1] == "-1":
+		ver1(sdk)
+	elif sys.argv[1] == "-2":
+		ver2(sdk)
+	else:
+		print "Illegal argument, try -h"
+		exit(1)
+	
+	print " # Creating symlink..."
+	os.symlink("app/build/app_resources.pbpack", "../system_resources.new.pbpack")
+	print " # Done! You may get pbpack at system_resources.new.pbpack"
+	print "   Also you may rebuild it with:  cd app; ./waf build"

--- a/unpackFirmware.py
+++ b/unpackFirmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import zipfile, zlib
 import os, sys, io

--- a/unpackFirmware.py
+++ b/unpackFirmware.py
@@ -26,22 +26,39 @@ def extract_content(pbz, content, output_dir):
 
 def extract_resources(pbpack, resourceMap, output_dir):
 	numbers = unpack('B', pbpack.read(1))[0]
-	print 'Find %d resources.' % numbers
+	print 'Resource pack has %d resources.' % numbers
 
 	pbpack.seek(4)
 	crc_from_json = unpack('I', pbpack.read(4))[0]
-	pbpack.seek(0x101c)
+	print 'Resource pack claims to have crc 0x%X.' % crc_from_json
+
+	offset=None # this will be set depending on firmware version
+
+	print 'Checking CRC with offset 0x100C (2.x)...'
+	pbpack.seek(0x100C)
 	crc_resource = crc32(pbpack.read())
-	
 	if crc_resource == crc_from_json:
-		print "\t[  OK] Check Resources CRC"
+		print '\t[  OK] This seems to be a 2.x firmware.'
+		offset = 0x0C
 	else:
-		print "\t[Fail] Check Resources CRC"
-		print "\tIt's 0x%x, but should be 0x%x" % (crc_from_json, crc_resource)
-	
+		print '\t[Info] It is not 2.x firmware, or is corrupted, CRC=0x%08X' % crc_resource
+		print 'Checking CRC with offset 0x101C (1.x)...'
+		pbpack.seek(0x101C)
+		crc_resource2 = crc32(pbpack.read())
+		if crc_resource2 == crc_from_json:
+			print '\t[  OK] This seems to be a 1.x firmware.'
+			offset = 0x1C
+		else:
+			print '\t[Fail] CRC check failed!'
+			print "\tShould be 0x%X, but if 0x%X for 100c and 0x%x for 101c." % (
+					crc_from_json, crc_resource, crc_resource2)
+			print 'Resource pack is either malformed or has unknown format.'
+			return
+
+	print 'Reading resurce headers...'
 	resources = {}
 	for i in range(numbers):
-		pbpack.seek(0x1C + i * 16)
+		pbpack.seek(offset + i * 16)
 		index = unpack('i', pbpack.read(4))[0] - 1
 		resources[index] = {
 			'offset': unpack('i', pbpack.read(4))[0],
@@ -49,45 +66,65 @@ def extract_resources(pbpack, resourceMap, output_dir):
 			'crc': unpack('I', pbpack.read(4))[0]
 		}
 
-	for i in range(len(resourceMap)):
-		path = resourceMap[i]['file']
+	for i in range(len(resourceMap or resources)):
+		entry = resources[i]
+		path = resourceMap[i]['file'] if resourceMap else 'res/%02d_%08X' % (i, entry['crc'])
 		dirname = os.path.dirname(path)
+		filepath = "/".join((dirname, resourceMap[i]['defName'])) if resourceMap else path
 
-		print 'Extracting %s...' % (dirname + "/" + resourceMap[i]['defName'])
+		print 'Extracting %s...' % filepath
 		mkdir(output_dir + dirname)
 
-		entry = resources[i]
-		pbpack.seek(0x101C + entry['offset'])
-		file = open(output_dir + dirname + "/" + resourceMap[i]['defName'], 'wb')
+		pbpack.seek(0x1000 + offset + entry['offset'])
+		file = open(output_dir + filepath, 'wb')
 		file.write(pbpack.read(entry['size']))
 		file.close()
 
-		data = io.FileIO(output_dir + dirname + "/" + resourceMap[i]['defName']).readall()
+		data = io.FileIO(output_dir + filepath).readall()
 		crc = crc32(data)
 		if crc == entry['crc']:
 			print '\t[  OK] Checking CRC...'
 		else:
 			print '\t[Fail] Checking CRC...'
-			print "\tIt's 0x%x, but should be 0x%x" % (entry['crc'], crc)
+			print "\tIt's 0x%x, but should be 0x%x" % (crc, entry['crc'])
+	print 'All resources unpacked.'
 		
 
 if __name__ == '__main__':
+	useNaming = True
+	if len(sys.argv) > 1 and sys.argv[1] == '-i':
+		useNaming = False
+		sys.argv.pop(1)
 
 	if len(sys.argv) <= 1:
-		print 'usage: unpackFirmware.py normal.pbz [output_dir]'
+		print 'Usage: unpackFirmware.py [-i] normal.pbz [output_dir/]'
+		print '    -i: ignore resource filenames from manifest.'
+		print '       By default, if manifest contains resource names'
+		print '       (as in 1.x firmwares), we will name resources'
+		print '       according to them.'
+		print '       With this option, resource names will be res/ID_CRC'
+		print '       where ID is sequence index of resource and CRC is'
+		print '       its CRC checksum (for comparing)'
+		print '       On 2.x firmwares, which don\'t contain resource names,'
+		print '       we always use that scheme.'
 		exit()
 
 	pbz_name = sys.argv[1]
 	if len(sys.argv) <= 2:
 		output_dir = 'pebble-firmware/'
 	else:
-		output_dir = sys.argv[2] + '/'
+		output_dir = sys.argv[2]
+		if not output_dir.endswith('/'):
+			output_dir += '/'
+	print 'Will unpack firmware from %s to directory %s, using %s for filenames' % (
+			pbz_name, output_dir,
+			'resource names (if possible)' if useNaming else 'resource indices')
+
 	pbz = zipfile.ZipFile(pbz_name)
 
 	print 'Extracting manifest.json...'
 	pbz.extract('manifest.json', output_dir)
 	manifest = json.load(open(output_dir + 'manifest.json', 'rb'))
-
 
 	firmware = manifest['firmware']
 	extract_content(pbz, firmware, output_dir)
@@ -96,6 +133,17 @@ if __name__ == '__main__':
 		resources = manifest['resources']
 		extract_content(pbz, resources, output_dir)	
 		
-		resourceMap = manifest['debug']['resourceMap']['media']	
+		if manifest['debug'].has_key('resourceMap'):
+			resourceMap = manifest['debug']['resourceMap']['media']	
+			print 'Found resource map in manifest. Looks like 1.x firmware.'
+			if useNaming:
+				print 'Will use it to name resources correctly. To ignore, pass -i option.'
+			else:
+				print 'Will not use it however because of -i option'
+		else:
+			resourceMap = None
+			print "Couldn't find resource map in manifest. Looks like 2.x firmware."
+			print 'Resources will be named by their indices.'
+			useNaming = False
 		pbpack = open(output_dir + resources['name'], 'rb')
-		extract_resources(pbpack, resourceMap, output_dir)
+		extract_resources(pbpack, resourceMap if useNaming else None, output_dir)

--- a/unpackFirmware.py
+++ b/unpackFirmware.py
@@ -66,11 +66,12 @@ def extract_resources(pbpack, resourceMap, output_dir):
 			'crc': unpack('I', pbpack.read(4))[0]
 		}
 
-	for i in range(len(resourceMap or resources)):
+	for i in range(len(resources)):
 		entry = resources[i]
-		path = resourceMap[i]['file'] if resourceMap else 'res/%02d_%08X' % (i, entry['crc'])
+		hasRM = resourceMap and i < len(resourceMap)
+		path = resourceMap[i]['file'] if hasRM else 'res/%02d_%08X' % (i, entry['crc'])
 		dirname = os.path.dirname(path)
-		filepath = "/".join((dirname, resourceMap[i]['defName'])) if resourceMap else path
+		filepath = "/".join((dirname, resourceMap[i]['defName'])) if hasRM else path
 
 		print 'Extracting %s...' % filepath
 		mkdir(output_dir + dirname)
@@ -133,7 +134,7 @@ if __name__ == '__main__':
 		resources = manifest['resources']
 		extract_content(pbz, resources, output_dir)	
 		
-		if manifest['debug'].has_key('resourceMap'):
+		if 'resourceMap' in manifest['debug']:
 			resourceMap = manifest['debug']['resourceMap']['media']	
 			print 'Found resource map in manifest. Looks like 1.x firmware.'
 			if useNaming:

--- a/updateResources.py
+++ b/updateResources.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import zipfile, zlib
+import os, os.path, sys, io
+import json
+from libpebble.stm32_crc import crc32
+from struct import pack, unpack
+import tempfile
+import shutil
+
+def getCrc(pbpack):
+	"""read CRC from a pbpack file"""
+	pbpack.seek(4)
+	return unpack('I', pbpack.read(4))[0]
+
+def updateCrc(tintin, nOld, nNew):
+	"""update CRC sum in tintin binary"""
+	old = pack('I', nOld)
+	new = pack('I', nNew)
+	fw = tintin.read()
+	i = fw.find(old)
+	if i < 0:
+		print "Oops... Couldn't find checksum 0x%08X in tintin_fw.bin! Maybe you specified incorrect data?.."
+		exit(1)
+	j = fw.find(old, i+1)
+	if not j < 0: # if it was not the only occurance
+		print "Oops... There are several occurances of possible checksum 0x%08X, at least at 0x%08X and 0x%08X." % (nOld, i, j)
+		print "Bailing out!"
+		exit(1)
+	print "Found the only occurance of old checksum 0x%08X at 0x%08X" % (nOld, i)
+	print "Replacing it with the new value 0x%08X..." % nNew
+	tintin.seek(i)
+	tintin.write(new)
+	tintin.flush()
+	print "OK."
+
+def parse_args():
+	def readable(f):
+		open(f, 'rb').close()
+		return f
+	import argparse
+	parser = argparse.ArgumentParser(description="Update checksums and pack firmware package with modified resource pbpack file")
+	parser.add_argument("outfile",
+			help="Output file, e.g. Pebble-1.10-ev2_4.pbz")
+	parser.add_argument("respack", type=readable,
+			help="Updated resource pack filename, e.g. app_resources.pbpack")
+	group = parser.add_mutually_exclusive_group(required=True)
+	group.add_argument("-o", "--original", type=argparse.FileType('rb'),
+			help="Original resource pack from the original firmware", metavar="ORIGINAL_RESPACK")
+	group.add_argument("-c", "--orig-crc", type=lambda x: int(x,16),
+			help="CRC sum from the original resource pack (hexadecimal), e.g. 0xDEADBE05", metavar="0xDEF01234")
+	parser.add_argument("-m", "--manifest", default="manifest.json", type=readable,
+			help="Manifest file from the original firmware, defaults to manifest.json")
+	parser.add_argument("-t", "--tintin-fw", "--tintin", default="tintin_fw.bin", type=readable,
+			help="Tintin_fw file from the original firmware, defaults to tintin_fw.bin")
+	group = parser.add_argument_group("Optional parameters")
+	group.add_argument("-k", "--keep-dir", action="store_true",
+			help="Don't remove temporary directory after work")
+	return parser.parse_args()
+
+if __name__ == "__main__":
+	args = parse_args()
+	if args.original:
+		args.orig_crc = getCrc(args.original)
+		args.original.close()
+	
+	print "Will create firmware at %s," % args.outfile
+	print "using %s for manifest, %s for tintin binary" % (args.manifest, args.tintin_fw)
+	print "and %s for resource pack" % args.respack 
+	print
+
+	try:
+		workdir = tempfile.mkdtemp()+'/'
+
+		print " # Copying new resource pack..."
+		shutil.copy(args.respack, workdir+'system_resources.pbpack')
+		with open(workdir+'system_resources.pbpack', 'rb') as newres:
+			newCrc = getCrc(newres)
+
+		print " # Copying tintin_fw.bin..."
+		shutil.copy(args.tintin_fw, workdir+'tintin_fw.bin')
+		print " # Updating CRC value in tintin_fw.bin from 0x%08X to 0x%08X:" % (args.orig_crc, newCrc)
+		with open(workdir+'tintin_fw.bin', 'r+b') as tintin:
+			updateCrc(tintin, args.orig_crc, newCrc)
+
+		print " # Reading manifest..."
+		with open(args.manifest, 'r') as f:
+			manifest = json.load(f)
+
+		print " # Updating manifest..."
+		rp_size = os.path.getsize(args.respack)
+		print "   res pack size = %d" % rp_size
+		with open(args.respack) as f:
+			rp_crc = crc32(f.read())
+		print "   res pack crc = %d" % rp_crc
+		with open(workdir+"tintin_fw.bin") as f:
+			tintin_crc = crc32(f.read())
+		print "   tintin crc = %d" % tintin_crc
+
+		print " # Changing values:"
+		print "  resources.size: %d => %d" % (manifest['resources']['size'], rp_size)
+		manifest['resources']['size'] = rp_size
+		print "  resources.crc: %d => %d" % (manifest['resources']['crc'], rp_crc)
+		manifest['resources']['crc'] = rp_crc
+		print "  firmware.crc: %d => %d" % (manifest['firmware']['crc'], tintin_crc)
+		manifest['firmware']['crc'] = tintin_crc
+
+		print " # Storing manifest..."
+		with open(workdir+"manifest.json", "wb") as f:
+			json.dump(manifest, f)
+		
+		print " # Creating output zip..."
+		with zipfile.ZipFile(args.outfile, "w", zipfile.ZIP_STORED) as z:
+			for f in ("tintin_fw.bin", "system_resources.pbpack", "manifest.json"):
+				print "   Storing %s..." % f
+				z.write(workdir+f, f)
+
+		print " # Done. Firmware is packed to %s" % args.outfile
+
+	finally:
+		if args.keep_dir:
+			print "Kept temporary files in %s" % workdir
+		else:
+			print "Removing temporary files..."
+			shutil.rmtree(workdir)
+


### PR DESCRIPTION
In new SDK 2.0-BETA1 pbpack format was changed. Now it missing version string, and all remaining data are shifted.
Here is an updated version of unpackFirmware.py which supports both old and new formats (see also commit messages).
Also here is a simple tool which calculates STM32 CRC sum of a given file. It is useful e.g. when updating manifest.json in a patched firmware.

UPD: I also added a couple of new tools:
updateResources.py repacks firmware using new resource pack and updates all required checksums (supports both 1.x and 2.x);
prepareResourceProject.py uses SDK to repack firmware into pbpack (currently only supports 1.x SDK)
